### PR TITLE
feat: Add database static role

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: amannn/action-semantic-pull-request@5.5.2
+        uses: amannn/action-semantic-pull-request@5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [vault_database_secret_backend_connection.connections](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/database_secret_backend_connection) | resource |
-| [vault_database_secret_backend_role.role](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/database_secret_backend_role) | resource |
+| [vault_database_secret_backend_role.roles](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/database_secret_backend_role) | resource |
+| [vault_database_secret_backend_static_role.roles](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/database_secret_backend_static_role) | resource |
 | [vault_mount.secret_engine](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/mount) | resource |
 | [vault_policy.policies](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy) | resource |
 
@@ -28,6 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_database_roles"></a> [database\_roles](#input\_database\_roles) | All Database Roles | `any` | `null` | no |
+| <a name="input_database_static_roles"></a> [database\_static\_roles](#input\_database\_static\_roles) | All Static Database Roles | `any` | `null` | no |
 | <a name="input_databases"></a> [databases](#input\_databases) | All Databases | `any` | `null` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | All Policies | `any` | `null` | no |
 | <a name="input_secret_engine"></a> [secret\_engine](#input\_secret\_engine) | Secret Engine | `any` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "vault_database_secret_backend_connection" "connections" {
   }
 }
 
-resource "vault_database_secret_backend_role" "role" {
+resource "vault_database_secret_backend_role" "roles" {
   for_each              = var.database_roles
   backend               = vault_mount.secret_engine[each.value.backend].path
   name                  = each.value.name
@@ -128,4 +128,12 @@ resource "vault_database_secret_backend_role" "role" {
   max_ttl               = try(each.value.max_ttl, null)
   credential_type       = try(each.value.credential_type, null)
   credential_config     = try(each.value.credential_config, null)
+}
+
+resource "vault_database_secret_backend_static_role" "roles" {
+  for_each = var.database_static_roles
+  backend  = vault_mount.secret_engine[each.value.backend].path
+  name     = each.value.name
+  db_name  = vault_database_secret_backend_connection.connections[each.value.db_name].name
+  username = each.value.username
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,9 @@ variable "database_roles" {
   type        = any
   default     = null
 }
+
+variable "database_static_roles" {
+  description = "All Static Database Roles"
+  type        = any
+  default     = null
+}


### PR DESCRIPTION
Add:  Database secret backend static roles can be used to manage 1-to-1 mapping of a Vault Role to a user in a database for the database.